### PR TITLE
[refactor]: Rename `KURA_BLOCK_STORE_PATH` in `peer_config.json`

### DIFF
--- a/packages/client/test/integration/config/peer_config.json
+++ b/packages/client/test/integration/config/peer_config.json
@@ -18,7 +18,7 @@
   },
   "KURA": {
     "INIT_MODE": "strict",
-    "BLOCK_STORE_PATH": "./blocks"
+    "BLOCK_STORE_PATH": "./storage"
   },
   "LOGGER": {
     "MAX_LOG_LEVEL": "INFO"


### PR DESCRIPTION
Just for consistency with the change of `DEFAULT_BLOCK_STORE_PATH` from `./blocks` to `./storage` in https://github.com/hyperledger/iroha/pull/2701
